### PR TITLE
feat(tlb/resolving): add all rule definitions in the go-to-definition popup for types

### DIFF
--- a/modules/tlb/src/org/ton/intellij/tlb/TlbIcons.kt
+++ b/modules/tlb/src/org/ton/intellij/tlb/TlbIcons.kt
@@ -7,4 +7,6 @@ object TlbIcons {
     val FILE = IconLoader.getIcon("/icons/tlb.svg", TlbIcons::class.java)
 
     val TYPE = AllIcons.Nodes.Type
+    val FIELD = AllIcons.Nodes.Field
+    val CONSTRUCTOR = AllIcons.Nodes.Constructor
 }

--- a/modules/tlb/src/org/ton/intellij/tlb/psi/elements.kt
+++ b/modules/tlb/src/org/ton/intellij/tlb/psi/elements.kt
@@ -31,8 +31,10 @@ abstract class TlbNamedElementImpl(node: ASTNode) : TlbElementImpl(node), TlbNam
 
     override fun getIcon(flags: Int): Icon? {
         return when (this) {
-            is TlbResultType -> TlbIcons.TYPE
-            else             -> return super.getIcon(flags)
+            is TlbResultType  -> TlbIcons.TYPE
+            is TlbField       -> TlbIcons.FIELD
+            is TlbConstructor -> TlbIcons.CONSTRUCTOR
+            else              -> return super.getIcon(flags)
         }
     }
 


### PR DESCRIPTION
Fixes #300

Before:
<img width="324" height="181" alt="Screenshot 2025-07-30 at 14 45 18" src="https://github.com/user-attachments/assets/e4124088-0da5-4f02-85b3-f9c5b2986a49" />

After:
<img width="845" height="224" alt="Screenshot 2025-07-30 at 14 44 53" src="https://github.com/user-attachments/assets/533fa370-ed4d-406a-aa22-5e154e2782ef" />
