### PR TITLE
fix(func/find-usages): fix kind names in find usages for parameters and local variables

### DIFF
--- a/modules/func/src/org/ton/intellij/func/ide/FuncFindUsagesProvider.kt
+++ b/modules/func/src/org/ton/intellij/func/ide/FuncFindUsagesProvider.kt
@@ -31,8 +31,10 @@ class FuncFindUsagesProvider : FindUsagesProvider {
         return when (element) {
             is FuncFunction -> "function"
             is FuncConstVar -> "constant"
-            is FuncGlobalVar -> "global var"
+            is FuncGlobalVar -> "global variable"
+            is FuncFunctionParameter -> "parameter"
             is FuncTypeParameter -> "type parameter"
+            is FuncReferenceExpression -> "local variable"
             else -> return "<TYPE $element>"
         }
     }


### PR DESCRIPTION


Fixes #444