### PR TITLE
fix: removed deprecation warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ allprojects {
 dependencies {
     intellijPlatform {
         val version = providers.gradleProperty("platformVersion")
-        create(IntelliJPlatformType.WebStorm, version)
+        webstorm(version)
     }
     implementation(project(":util"))
     implementation(project(":blueprint"))


### PR DESCRIPTION
```
build.gradle.kts:63:9: 'fun create(type: IntelliJPlatformType, version: Provider<String>, useInstaller: Boolean = ..., productMode: ProductMode = ...): Unit' is deprecated. Please use the create(type, version, configure) method with a configuration lambda instead.
```