### PR TITLE
fix(func): test launch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
         val version = providers.gradleProperty("platformVersion")
         rustRover(version)
         bundledPlugin("org.toml.lang")
+        bundledPlugin("com.intellij.modules.json")
         testFramework(TestFrameworkType.Platform)
     }
     implementation(project(":util"))


### PR DESCRIPTION
Как я понимаю всё из-за того, что раскрытие и резол `plugin.xml` происходит в основном проекте, а модуль `acton` требует `com.intellij.modules.json`, которого как раз нет в главном проекте. Это можно проверить и на минимальном `plugin.xml`, если сломать его через `<depends>`