### PR TITLE
fix(tolk): use `createEmptyMap()` as a default value for map field

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkExpressionFieldProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkExpressionFieldProvider.kt
@@ -171,6 +171,9 @@ object TolkExpressionFieldProvider : TolkCompletionProvider() {
         }
 
         if (type is TolkTyStruct) {
+            if (type.psi.name == "map") {
+                return "createEmptyMap()"
+            }
             if (type.typeArguments.isNotEmpty() && type.psi.name == "Cell") {
                 // `Cell<T>` -> `T {}.toCell()` or `defaultOf(T).toCell()`
                 val arg = type.typeArguments[0]


### PR DESCRIPTION
Fixes #675