### PR TITLE
feat(tolk): don't consider `_x` parameters as unused

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/inspection/TolkUnusedFunctionParameterInspection.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/inspection/TolkUnusedFunctionParameterInspection.kt
@@ -25,8 +25,8 @@ class TolkUnusedFunctionParameterInspection : TolkInspectionBase() {
             }
 
             private fun processParameter(parameter: TolkParameter, searchScope: SearchScope) {
-                val id = parameter.identifier ?: return
-                if (id.textMatches("_")) return
+                val id = parameter.identifier
+                if (id.text.startsWith("_")) return
                 if (ReferencesSearch.search(parameter, searchScope).none()) {
                     holder.registerProblem(
                         parameter,

--- a/modules/tolk/test/inspection/TolkUnusedFunctionParameterInspectionTest.kt
+++ b/modules/tolk/test/inspection/TolkUnusedFunctionParameterInspectionTest.kt
@@ -1,0 +1,23 @@
+package org.ton.intellij.tolk.inspection
+
+class TolkUnusedFunctionParameterInspectionTest : TolkInspectionTestBase() {
+    fun `test ignore unused parameter with underscore prefix`() {
+        checkNoProblems(
+            """
+            fun main(_value: int) {
+            }
+            """.trimIndent(),
+            TolkUnusedFunctionParameterInspection(),
+        )
+    }
+
+    fun `test ignore several unused parameters with underscore prefix`() {
+        checkNoProblems(
+            """
+            fun main(_left: int, _right: int) {
+            }
+            """.trimIndent(),
+            TolkUnusedFunctionParameterInspection(),
+        )
+    }
+}


### PR DESCRIPTION
Fixes #700 