### PR TITLE
fix(acton): wallet address regex

### DIFF
--- a/modules/acton/src/org/ton/intellij/acton/ide/ActonTonAddressConsoleFilter.kt
+++ b/modules/acton/src/org/ton/intellij/acton/ide/ActonTonAddressConsoleFilter.kt
@@ -60,7 +60,7 @@ class ActonTonAddressConsoleFilter : Filter {
 
     companion object {
         private val rawPattern = Regex("""\b-?[0-9]:[0-9a-fA-F]{64}\b""")
-        private val userFriendlyPattern = Regex("""\b[EfUk0][Qf][a-zA-Z0-9+_-]{46}\b""")
+        private val userFriendlyPattern = Regex("""\b[EfUk0][Qf][a-zA-Z0-9+_-]{46}(?![A-Za-z0-9+_-])""")
     }
 }
 


### PR DESCRIPTION
Now, addresses ending in `+` or `-` can be found, provided that no character follows that is included in `base64` or `URL-safe base64`

```
0Q000000000000000000000000000000000000000000000-
0f000000000000000000000000000000000000000000000+
EQ000000000000000000000000000000000000000000000_
```